### PR TITLE
Add BUILD.gn to func package

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,13 @@
+# Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
+import("//build/dart/dart_package.gni")
+
+dart_package("func") {
+  package_name = "func"
+
+  source_dir = "lib"
+
+  disable_analysis = true
+}


### PR DESCRIPTION
I'm running into issues building our dart dependencies inside fuchsia (fuchsia.googlesource.com) - I need to add a BUILD.gn so our build system can explicitly pickup func, which fixes the issue. (see e.g. https://chromium.googlesource.com/external/github.com/dart-lang/linter/+/8bc028c39983586bb1374e66820c8bcc813f21b4)